### PR TITLE
Fix for Java demos, WSS issues 571, 972 & 973

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ out
 build-local.properties
 .gradle
 build
+gradle
+gradlew
+gradlew.bat
 
 # Github java basic 
 *.class

--- a/j2se/java-amqp-demo/README.md
+++ b/j2se/java-amqp-demo/README.md
@@ -39,7 +39,7 @@ build\install\java-amqp-demo\bin\java-amqp-demo.bat
 ```
 - To use credentials with our default URI:
 ```
-/java-aqmp-demo 'username' 'password'
+/java-aqmp-demo 'guest' 'guest'
 ```
 - If you have setup your gateway for authentification:
 ```

--- a/j2se/java-amqp-demo/README.md
+++ b/j2se/java-amqp-demo/README.md
@@ -9,6 +9,8 @@ This J2SE console app communicates over WebSocket with an AMQP server via Kaazin
 
 ## Steps for Building and Running the Project
 
+- Install gradle: follow the steps [here](https://gradle.org/gradle-download/).
+
 - Build the application using gradle
 
 ```bash
@@ -25,6 +27,25 @@ or
 ```
 build\install\java-amqp-demo\bin\java-amqp-demo.bat
 ```
+
+**NOTE** The application can be run in the folowing ways:
+	1. If you want to connect to our default URI and default credentials (guest/guest):
+	```
+	/java-amqp-demo
+	```
+	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/zmqp*):
+	```
+	/java-jms-demo '{YOUR.GATEWAY.URI}'
+	```
+	3. If you want to use credentials with our default URI:
+	```
+	/java-aqmp-demo 'username' `password`
+	```
+	4. If you have setup your gateway for authentification:
+	```
+	/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
+	```
+
 **Note:** If you encounter an exception, try running the program as the root user (`sudo`).
 
 ## Interact with Kaazing Java AMQP Client API

--- a/j2se/java-amqp-demo/README.md
+++ b/j2se/java-amqp-demo/README.md
@@ -28,7 +28,7 @@ or
 build\install\java-amqp-demo\bin\java-amqp-demo.bat
 ```
 
-**NOTE** The application can be run in the folowing ways:
+**NOTE:** The application can be run in the folowing ways:
 - To connect to our default URI and default credentials (guest/guest):
 ```
 /java-amqp-demo
@@ -39,7 +39,7 @@ build\install\java-amqp-demo\bin\java-amqp-demo.bat
 ```
 - To use credentials with our default URI:
 ```
-/java-aqmp-demo 'username' `password`
+/java-aqmp-demo 'username' 'password'
 ```
 - If you have setup your gateway for authentification:
 ```

--- a/j2se/java-amqp-demo/README.md
+++ b/j2se/java-amqp-demo/README.md
@@ -29,22 +29,22 @@ build\install\java-amqp-demo\bin\java-amqp-demo.bat
 ```
 
 **NOTE** The application can be run in the folowing ways:
-	1. If you want to connect to our default URI and default credentials (guest/guest):
-	```
-	/java-amqp-demo
-	```
-	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/zmqp*):
-	```
-	/java-jms-demo '{YOUR.GATEWAY.URI}'
-	```
-	3. If you want to use credentials with our default URI:
-	```
-	/java-aqmp-demo 'username' `password`
-	```
-	4. If you have setup your gateway for authentification:
-	```
-	/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
-	```
+- To connect to our default URI and default credentials (guest/guest):
+```
+/java-amqp-demo
+```
+- To connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/zmqp*):
+```
+/java-jms-demo '{YOUR.GATEWAY.URI}'
+```
+- To use credentials with our default URI:
+```
+/java-aqmp-demo 'username' `password`
+```
+- If you have setup your gateway for authentification:
+```
+/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
+```
 
 **Note:** If you encounter an exception, try running the program as the root user (`sudo`).
 

--- a/j2se/java-amqp-demo/build.gradle
+++ b/j2se/java-amqp-demo/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 sourceCompatibility = 1.8
-mainClassName = 'com.kaazing.amqp.client.demo.JavaAmqpClientDemo'
+mainClassName = 'com.kaazing.amqp.client.demo.AmqpDemoClientMain'
 
 
 repositories {

--- a/j2se/java-amqp-demo/src/main/java/com/kaazing/amqp/client/demo/AmqpDemoClientMain.java
+++ b/j2se/java-amqp-demo/src/main/java/com/kaazing/amqp/client/demo/AmqpDemoClientMain.java
@@ -1,0 +1,51 @@
+package com.kaazing.amqp.client.demo;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AmqpDemoClientMain {
+    public static void main(String[] args) throws InterruptedException, URISyntaxException, IOException {
+        JavaAmqpClientDemo demo = null;
+        switch (args.length){
+            case 0:
+                demo = new JavaAmqpClientDemo("ws://sandbox.kaazing.net/amqp091", "guest", "guest");
+                break;
+            case 1:
+                demo = new JavaAmqpClientDemo(args[0], "guest", "guest");
+                break;
+            case 2:
+                demo = new JavaAmqpClientDemo("ws://sandbox.kaazing.net/jms", args[0], args[1]);
+                break;
+            case 3:
+                demo = new JavaAmqpClientDemo(args[0], args[1], args[2]);
+                break;
+            default:
+                System.out.println("Possible usage of the Kaazing Java JMS Demo: \n" +
+                        "   1. If you want to connect to our default URI and default credentials (guest/guest): \n" +
+                        "       /java-amqp-demo\n" +
+                        "   2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):\n" +
+                        "       /java-amqp-demo '{YOUR.GATEWAY.URI}' \n" +
+                        "   3. If you want to use authentication with our default URI: \n" +
+                        "       /java-aqmp-demo 'username' `password` \n" +
+                        "   4. If you have setup your gateway for authentication: \n" +
+                        "       /java-amqp-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' \n" +
+                        "Please restart your the Kaazing Java AMQP Demo and input the correct parameters as stated above!");
+                System.exit(1);
+        }
+        demo.handleConnection();
+        System.out.println("Kaazing Java AMQP Demo App. Copyright (C) 2017 Kaazing, Inc.");
+        System.out.println("Type the message to send or <exit> to stop.");
+        BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
+        while (true) {
+            String text = console.readLine();
+            if (text.equalsIgnoreCase("<exit>"))
+                break;
+            // Send as a text
+            demo.sendMessage(text);
+        }
+        demo.disconnect();
+    }
+}

--- a/j2se/java-jms-demo/README.md
+++ b/j2se/java-jms-demo/README.md
@@ -9,6 +9,8 @@ This J2SE console app communicates over WebSocket with a JMS server via Kaazing 
 
 ## Steps for building and running the project
 
+- Install gradle: follow the steps [here](https://gradle.org/gradle-download/).
+
 - Build the application using gradle
 
 ```bash
@@ -24,6 +26,23 @@ or
 ```
 build\install\java-jms-demo\bin\java-jms-demo.bat
 ```
+**NOTE** The application can be run in the folowing ways:
+	1. If you want to connect to our defult URI:
+	```
+	/java-jms-demo
+	```
+	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):
+	```
+	/java-jms-demo '{YOUR.GATEWAY.URI}'
+	```
+	3. If you want to use credentials with our default URI:
+	```
+	/java-jms-demo 'joe' `welcome`
+	```
+	4. If you have setup your gateway for authentification:
+	```
+	/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
+	```
 
 ## Interact with Kaazing Java WebSocket Client API
 

--- a/j2se/java-jms-demo/README.md
+++ b/j2se/java-jms-demo/README.md
@@ -27,22 +27,22 @@ or
 build\install\java-jms-demo\bin\java-jms-demo.bat
 ```
 **NOTE** The application can be run in the folowing ways:
-	1. If you want to connect to our defult URI:
-	```
-	/java-jms-demo
-	```
-	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):
-	```
-	/java-jms-demo '{YOUR.GATEWAY.URI}'
-	```
-	3. If you want to use credentials with our default URI:
-	```
-	/java-jms-demo 'joe' `welcome`
-	```
-	4. If you have setup your gateway for authentification:
-	```
-	/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
-	```
+- To connect to our defult URI:
+```
+/java-jms-demo
+```
+-To your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):
+```
+/java-jms-demo '{YOUR.GATEWAY.URI}'
+```
+- To use credentials with our default URI:
+```
+/java-jms-demo 'joe' `welcome`
+```
+- If you have setup your gateway for authentification :
+```
+/java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' 
+```
 
 ## Interact with Kaazing Java WebSocket Client API
 

--- a/j2se/java-jms-demo/README.md
+++ b/j2se/java-jms-demo/README.md
@@ -37,7 +37,7 @@ build\install\java-jms-demo\bin\java-jms-demo.bat
 ```
 - To use credentials with our default URI:
 ```
-/java-jms-demo 'joe' `welcome`
+/java-jms-demo 'joe' 'welcome'
 ```
 - If you have setup your gateway for authentification :
 ```

--- a/j2se/java-jms-demo/README.md
+++ b/j2se/java-jms-demo/README.md
@@ -26,7 +26,7 @@ or
 ```
 build\install\java-jms-demo\bin\java-jms-demo.bat
 ```
-**NOTE** The application can be run in the folowing ways:
+**NOTE:** The application can be run in the folowing ways:
 - To connect to our defult URI:
 ```
 /java-jms-demo

--- a/j2se/java-jms-demo/build.gradle
+++ b/j2se/java-jms-demo/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 sourceCompatibility = 1.8
-mainClassName = 'com.kaazing.jms.client.demo.JavaJMSClientDemo'
+mainClassName = 'com.kaazing.jms.client.demo.JMSDemoClientMain'
  
 
 repositories {

--- a/j2se/java-jms-demo/src/main/java/com/kaazing/jms/client/demo/JMSDemoClientMain.java
+++ b/j2se/java-jms-demo/src/main/java/com/kaazing/jms/client/demo/JMSDemoClientMain.java
@@ -1,0 +1,58 @@
+package com.kaazing.jms.client.demo;
+
+import javax.jms.JMSException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by azaharia on 02.02.2017.
+ */
+public class JMSDemoClientMain {
+
+    public static void main(String[] args) throws InterruptedException, URISyntaxException, IOException, JMSException {
+        JavaJMSClientDemo demo = null;
+        switch (args.length){
+            case 0:
+                demo = new JavaJMSClientDemo(new URI("ws://sandbox.kaazing.net/jms"), "", "");
+                break;
+            case 1:
+                demo = new JavaJMSClientDemo(new URI(args[0]), "", "");
+                break;
+            case 2:
+                demo = new JavaJMSClientDemo(new URI("ws://sandbox.kaazing.net/jms"), args[0], args[1]);
+                break;
+            case 3:
+                demo = new JavaJMSClientDemo(new URI(args[0]), args[1], args[2]);
+                break;
+            default:
+                System.out.println("Possible usage of the Kaazing Java JMS Demo: \n" +
+                        "   1. If you want to connect to our default URI: \n" +
+                        "       /java-jms-demo\n" +
+                        "   2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):\n" +
+                        "       /java-jms-demo '{YOUR.GATEWAY.URI}' \n" +
+                        "   3. If you want to use authentication with our default URI: \n" +
+                        "       /java-jms-demo 'joe' `welcome` \n" +
+                        "   4. If you have setup your gateway for authentication: \n" +
+                        "       /java-jms-demo '{YOUR.GATEWAY.URI}' '{USERNAME}' '{PASSWORD}' \n" +
+                        "Please restart your the Kaazing Java JMS Demo and input the correct parameters as stated above!");
+                System.exit(1);
+        }
+        demo.handleConnection();
+        System.out.println("Kaazing Java JMS Demo App. Copyright (C) 2017 Kaazing, Inc.");
+        System.out.println("Type the message to send or <exit> to stop.");
+        BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
+        System.out.print("User input: ");
+        while (true) {
+            String text = console.readLine();
+            if (text.equalsIgnoreCase("<exit>"))
+                break;
+            // Send as a text
+            demo.sendMessage(text);
+        }
+        demo.disconnect();
+    }
+
+}

--- a/j2se/java-jms-demo/src/main/java/com/kaazing/jms/client/demo/JavaJMSClientDemo.java
+++ b/j2se/java-jms-demo/src/main/java/com/kaazing/jms/client/demo/JavaJMSClientDemo.java
@@ -27,160 +27,150 @@ import com.kaazing.net.http.HttpRedirectPolicy;
 import com.kaazing.net.ws.WebSocketFactory;
 
 public class JavaJMSClientDemo {
-	private InitialContext jndiInitialContext;
-	private ConnectionFactory connectionFactory;
-	private Connection connection;
-	private Session session;
+    private InitialContext jndiInitialContext;
+    private ConnectionFactory connectionFactory;
+    private Connection connection;
+    private Session session;
 
-	private final String subTopicName = "echo";
-	private final String pubTopicName = "echo";
-	private MessageProducer producer;
-	private MessageConsumer consumer;
+    private final URI url;
+    private final String login;
+    private final String password;
+    private final String subTopicName = "echo";
+    private final String pubTopicName = "echo";
+    private MessageProducer producer;
+    private MessageConsumer consumer;
 
-	public JavaJMSClientDemo(URI url, String login, String password) throws JMSException {
+    public JavaJMSClientDemo(URI url, String login, String password) throws JMSException {
+        this.url = url;
+        this.login = login;
+        this.password = password;
+    }
 
-		Properties env = new Properties();
-		env.setProperty("java.naming.factory.initial", "com.kaazing.gateway.jms.client.JmsInitialContextFactory");
-		try {
-			jndiInitialContext = new InitialContext(env);
-		} catch (NamingException e1) {
-			throw new RuntimeException("Error creating initial context factory for JMS!", e1);
-		}
-		env.put(JmsInitialContext.CONNECTION_TIMEOUT, "15000");
-		try {
-			connectionFactory = (ConnectionFactory) jndiInitialContext.lookup("ConnectionFactory");
-		} catch (NamingException e) {
-			throw new RuntimeException("Error locating connection factory for JMS!", e);
-		}
-		JmsConnectionFactory jmsConnectionFactory = (JmsConnectionFactory) connectionFactory;
-		jmsConnectionFactory.setGatewayLocation(url);
-		WebSocketFactory webSocketFactory = jmsConnectionFactory.getWebSocketFactory();
-		webSocketFactory.setDefaultRedirectPolicy(HttpRedirectPolicy.ALWAYS);
-		try {
-			connection = connectionFactory.createConnection(login, password);
-		} catch (JMSException e) {
-			throw new RuntimeException("Error connecting to gateway with " + url.toString() + ", credentials " + login + "/" + password, e);
-		}
-		try {
-			connection.setExceptionListener(new ExceptionListener() {
+    public void handleConnection() throws JMSException {
+        if(login.equals("") && password.equals("")){
+            System.out.println("Connecting to: " + url + ". Please wait!");
+        }else {
+            System.out.println("Connecting to: " + url + " with username: " + login + "and password: " + password + ". Please wait!");
+        }
+        Properties env = new Properties();
+        env.setProperty("java.naming.factory.initial", "com.kaazing.gateway.jms.client.JmsInitialContextFactory");
+        try {
+            jndiInitialContext = new InitialContext(env);
+        } catch (NamingException e1) {
+            throw new RuntimeException("Error creating initial context factory for JMS!", e1);
+        }
+        env.put(JmsInitialContext.CONNECTION_TIMEOUT, "15000");
+        try {
+            connectionFactory = (ConnectionFactory) jndiInitialContext.lookup("ConnectionFactory");
+        } catch (NamingException e) {
+            throw new RuntimeException("Error locating connection factory for JMS!", e);
+        }
+        JmsConnectionFactory jmsConnectionFactory = (JmsConnectionFactory) connectionFactory;
+        jmsConnectionFactory.setGatewayLocation(url);
+        WebSocketFactory webSocketFactory = jmsConnectionFactory.getWebSocketFactory();
+        webSocketFactory.setDefaultRedirectPolicy(HttpRedirectPolicy.ALWAYS);
+        try {
+            connection = connectionFactory.createConnection(login, password);
+        } catch (JMSException e) {
+            System.out.println("EXCEPTION: " + e.getMessage() + ".\n" +
+                    " Please check the inputed URI, username, password and restart the demo!");
+            throw new RuntimeException("Error connecting to gateway with " + url.toString() + ", credentials " + login + "/" + password, e);
+        }
+        try {
+            connection.setExceptionListener(exception -> System.err.println("JMS Exception occurred " + exception.getMessage()));
+        } catch (JMSException e) {
+            throw new RuntimeException("Error setting exceptions listener. Connection: " + url.toString() + ", credentials " + login + "/" + password, e);
+        }
+        try {
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        } catch (JMSException e) {
+            connection.close();
+            throw new RuntimeException("Error creating session. Connection: " + url.toString() + ", credentials " + login + "/" + password, e);
+        }
+        try {
+            connection.start();
+        } catch (JMSException e) {
+            throw new RuntimeException("Error starting connection: " + url.toString() + ", credentials " + login + "/" + password, e);
+        }
+        System.out.println("Connected to " + url.toString());
+        Destination subDestination;
+        try {
+            subDestination = (Destination) jndiInitialContext.lookup("/topic/" + subTopicName);
+        } catch (NamingException e) {
+            connection.stop();
+            connection.close();
+            throw new RuntimeException("Cannot locate subscription topic " + subTopicName, e);
+        }
+        try {
 
-				public void onException(JMSException exception) {
-					System.err.println("JMS Exception occurred " + exception.getMessage());
+            consumer = session.createConsumer(subDestination);
+        } catch (JMSException e) {
+            session.close();
+            connection.stop();
+            connection.close();
+            throw new RuntimeException("Cannot create consumer for subscription topic " + subTopicName, e);
+        }
+        System.out.println("Created subscription to  destination: /topic/" + subTopicName + " for connection to " + url);
+        try {
+            consumer.setMessageListener(message -> {
+                if (message instanceof TextMessage) {
+                    try {
+                        System.out.println("<- MESSAGE RECEIVED: " + ((TextMessage) message).getText());
+                        System.out.print("User input: ");
+                    } catch (JMSException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    System.err.println("Received message of an unexpected type " + message.getClass().getName());
+                }
+            });
+        } catch (JMSException e) {
+            session.close();
+            connection.stop();
+            connection.close();
+            throw new RuntimeException("Cannot create messages listener for subscription topic " + subTopicName, e);
 
-				}
-			});
-		} catch (JMSException e) {
-			throw new RuntimeException("Error setting exceptions listener. Connection: " + url.toString() + ", credentials " + login + "/" + password, e);
-		}
-		try {
-			session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-		} catch (JMSException e) {
-			connection.close();
-			throw new RuntimeException("Error creating session. Connection: " + url.toString() + ", credentials " + login + "/" + password, e);
-		}
-		try {
-			connection.start();
-		} catch (JMSException e) {
-			throw new RuntimeException("Error starting connection: " + url.toString() + ", credentials " + login + "/" + password, e);
-		}
-		System.out.println("Connected to " + url.toString());
-		Destination subDestination;
-		try {
-			subDestination = (Destination) jndiInitialContext.lookup("/topic/" + subTopicName);
-		} catch (NamingException e) {
-			connection.stop();
-			connection.close();
-			throw new RuntimeException("Cannot locate subscription topic " + subTopicName, e);
-		}
-		try {
+        }
+        Destination pubDestination;
+        try {
+            pubDestination = (Destination) jndiInitialContext.lookup("/topic/" + pubTopicName);
+        } catch (NamingException e) {
+            consumer.close();
+            session.close();
+            connection.stop();
+            connection.close();
 
-			consumer = session.createConsumer(subDestination);
-		} catch (JMSException e) {
-			session.close();
-			connection.stop();
-			connection.close();
-			throw new RuntimeException("Cannot create consumer for subscription topic " + subTopicName, e);
-		}
-		System.out.println("Created subscription to " + subTopicName + " for connection to " + url);
-		try {
-			consumer.setMessageListener(new MessageListener() {
+            throw new RuntimeException("Cannot locate publishing topic " + pubTopicName, e);
+        }
+        try {
+            producer = session.createProducer(pubDestination);
+        } catch (JMSException e) {
+            consumer.close();
+            session.close();
+            connection.stop();
+            connection.close();
+            throw new RuntimeException("Cannot create producer for publishing topic " + pubTopicName, e);
+        }
+    }
 
-				public void onMessage(Message message) {
-					if (message instanceof TextMessage) {
-						try {
-							System.out.println(">>> MESSAGE RECEIVED: " + ((TextMessage) message).getText());
-						} catch (JMSException e) {
-							// TODO Auto-generated catch block
-							e.printStackTrace();
-						}
-					} else {
-						System.err.println("Received message of an unexpected type " + message.getClass().getName());
-					}
+    public void disconnect() throws JMSException {
+        producer.close();
+        consumer.close();
+        session.close();
+        connection.stop();
+        connection.close();
+        System.out.println("Kaazing Java JMS Demo terminated successfully");
 
-				}
-			});
-		} catch (JMSException e) {
-			session.close();
-			connection.stop();
-			connection.close();
-			throw new RuntimeException("Cannot create messages listener for subscription topic " + subTopicName, e);
+    }
 
-		}
-		Destination pubDestination;
-		try {
-			pubDestination = (Destination) jndiInitialContext.lookup("/topic/" + pubTopicName);
-		} catch (NamingException e) {
-			consumer.close();
-			session.close();
-			connection.stop();
-			connection.close();
-
-			throw new RuntimeException("Cannot locate publishing topic " + pubTopicName, e);
-		}
-		try {
-			producer = session.createProducer(pubDestination);
-		} catch (JMSException e) {
-			consumer.close();
-			session.close();
-			connection.stop();
-			connection.close();
-			throw new RuntimeException("Cannot create producer for publishing topic " + pubTopicName, e);
-		}
-	}
-
-	public void disconnect() throws JMSException {
-		producer.close();
-		consumer.close();
-		session.close();
-		connection.stop();
-		connection.close();
-
-	}
-
-	public void sendMessage(String message) {
-		TextMessage textMessage;
-		try {
-			textMessage = session.createTextMessage(message);
-			producer.send(textMessage);
-		} catch (JMSException e) {
-			System.err.println("Error sending message [" + message + "]! " + e.getMessage());
-		}
-		System.out.println("MESSAGE PUBLISHED: " + message);
-	}
-
-	public static void main(String[] args) throws InterruptedException, URISyntaxException, IOException, JMSException {
-		JavaJMSClientDemo demo = new JavaJMSClientDemo(new URI("wss://sandbox.kaazing.net/jms"), "", "");
-		System.out.println("Kaazing Java JMS Demo App. Copyright (C) 2016 Kaazing, Inc.");
-		System.out.println("Type the message to send or <exit> to stop.");
-		BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
-		while (true) {
-			String text = console.readLine();
-			if (text.toLowerCase().equals("<exit>"))
-				break;
-			// Send as a text
-			demo.sendMessage(text);
-		}
-		demo.disconnect();
-	}
-
+    public void sendMessage(String message) {
+        TextMessage textMessage;
+        try {
+            textMessage = session.createTextMessage(message);
+            producer.send(textMessage);
+        } catch (JMSException e) {
+            System.err.println("Error sending message [" + message + "]! " + e.getMessage());
+        }
+        System.out.println("-> MESSAGE PUBLISHED: " + message);
+    }
 }

--- a/j2se/java-ws-demo/README.md
+++ b/j2se/java-ws-demo/README.md
@@ -28,14 +28,14 @@ or
 build\install\java-ws-demo\bin\java-ws-demo.bat
 ```
 **NOTE** The application can be run in the folowing ways:
-	1. If you want to connect to our defult URI:
-	```
-	/java-ws-demo
-	```
-	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/echo*):
-	```
-	/java-ws-demo '{YOUR.GATEWAY.URI}'
-	```
+- To connect to our defult URI:
+```
+/java-ws-demo
+```
+- To connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/echo*):
+```
+/java-ws-demo '{YOUR.GATEWAY.URI}'
+```
 
 **Note:** If you encounter an exception, try running the program as the root user (`sudo`).
 

--- a/j2se/java-ws-demo/README.md
+++ b/j2se/java-ws-demo/README.md
@@ -27,7 +27,7 @@ or
 ```
 build\install\java-ws-demo\bin\java-ws-demo.bat
 ```
-**NOTE** The application can be run in the folowing ways:
+**NOTE:** The application can be run in the folowing ways:
 - To connect to our defult URI:
 ```
 /java-ws-demo

--- a/j2se/java-ws-demo/README.md
+++ b/j2se/java-ws-demo/README.md
@@ -9,6 +9,8 @@ This J2SE console app communicates over WebSocket with an `Echo` service hosted 
 
 ## Steps for Building and Running the Project
 
+- Install gradle: follow the steps [here](https://gradle.org/gradle-download/).
+
 - Build the application using gradle
 
 ```bash
@@ -25,14 +27,25 @@ or
 ```
 build\install\java-ws-demo\bin\java-ws-demo.bat
 ```
+**NOTE** The application can be run in the folowing ways:
+	1. If you want to connect to our defult URI:
+	```
+	/java-ws-demo
+	```
+	2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/echo*):
+	```
+	/java-ws-demo '{YOUR.GATEWAY.URI}'
+	```
 
-Interact with Kaazing Java WebSocket Client API
+**Note:** If you encounter an exception, try running the program as the root user (`sudo`).
 
-Documentation that explains how to create a Kaazing Java WebSocket application from scratch can be found [here](http://kaazing.com/doc/5.0/websocket_client_docs/dev-java/o_dev_java.html).
+## Interact with Kaazing Java AMQP Client API
+
+Documentation that explains how to create a Kaazing Java AMQP application from scratch to send and receive AMQP messages over WebSocket can be found [here](http://kaazing.com/doc/5.0/amqp_client_docs/dev-java/o_dev_java.html).
 
 ## API Documentation
 
-API Documentation for Kaazing Java WebSocket Client library is available:
+API Documentation for Kaazing Java AMQP Client library is available:
 
-* [Kaazing WebSocket](http://kaazing.com/doc/5.0/websocket_client_docs/apidoc/client/java/gateway/index.html)
+* [Kaazing AMQP](http://kaazing.com/doc/5.0/amqp_client_docs/apidoc/client/java/amqp/client/index.html)
 

--- a/j2se/java-ws-demo/build.gradle
+++ b/j2se/java-ws-demo/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 sourceCompatibility = 1.8
-mainClassName = 'com.kaazing.ws.client.demo.JavaWsClientDemo'
+mainClassName = 'com.kaazing.ws.client.demo.WSDemoClientMain'
 
 repositories {
     mavenCentral()

--- a/j2se/java-ws-demo/src/main/java/com/kaazing/ws/client/demo/JavaWsClientDemo.java
+++ b/j2se/java-ws-demo/src/main/java/com/kaazing/ws/client/demo/JavaWsClientDemo.java
@@ -18,10 +18,15 @@ import com.kaazing.net.ws.WebSocketMessageWriter;
 public class JavaWsClientDemo {
 	private WebSocketFactory wsFactory;
 	private WebSocket webSocket;
+	private final URI url;
 
 
 
 	public JavaWsClientDemo(URI url) throws URISyntaxException, IOException {
+		this.url = url;
+	}
+
+	public void handleConnection() {
 		wsFactory = WebSocketFactory.createWebSocketFactory();
 		wsFactory.setDefaultRedirectPolicy(HttpRedirectPolicy.ALWAYS);
 		final URI wsUrl = url;
@@ -29,18 +34,21 @@ public class JavaWsClientDemo {
 			public void run() {
 				try {
 					webSocket = wsFactory.createWebSocket(wsUrl);
-
+                    System.out.println("Connecting to: " + wsUrl + ". Please wait!");
 					webSocket.connect();
 					final WebSocketMessageReader messageReader = webSocket.getMessageReader();
 					WebSocketMessageType type = null;
 					System.out.println("Connected to "+wsUrl);
 					System.out.println("Type the message to send or <exit> to stop.");
+                    System.out.print("\nUser input: ");
 					while ((type = messageReader.next()) != WebSocketMessageType.EOS) {
 						switch (type) {
 
 						case TEXT:
 							CharSequence text = messageReader.getText();
-							System.out.println(">>> RESPONSE:" + text.toString());
+							System.out.println("<- RESPONSE:" + text.toString());
+                            System.out.print("\nUser input: ");
+
 							break;
 						default:
 							System.err.println("Received a message of unexpected type: " + type);
@@ -64,21 +72,9 @@ public class JavaWsClientDemo {
 	public void sendMessage(String message) throws IOException {
 		WebSocketMessageWriter messageWriter = webSocket.getMessageWriter();
 		messageWriter.writeText(message);
-		System.out.println("MESSAGE PUBLISHED: " + message);
+		System.out.println("-> MESSAGE PUBLISHED: " + message);
 	}
 
-	public static void main(String[] args) throws InterruptedException, URISyntaxException, IOException, JMSException {
-		JavaWsClientDemo demo = new JavaWsClientDemo(new URI("wss://sandbox.kaazing.net/echo"));
-		System.out.println("Kaazing Java WebSocket	 Demo App. Copyright (C) 2016 Kaazing, Inc.");		
-		BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
-		while (true) {
-			String text = console.readLine();
-			if (text.toLowerCase().equals("<exit>"))
-				break;
-			// Send as a text
-			demo.sendMessage(text);
-		}
-		demo.disconnect();
-	}
+
 
 }

--- a/j2se/java-ws-demo/src/main/java/com/kaazing/ws/client/demo/WSDemoClientMain.java
+++ b/j2se/java-ws-demo/src/main/java/com/kaazing/ws/client/demo/WSDemoClientMain.java
@@ -1,0 +1,41 @@
+package com.kaazing.ws.client.demo;
+
+import javax.jms.JMSException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class WSDemoClientMain {
+    public static void main(String[] args) throws InterruptedException, URISyntaxException, IOException, JMSException {
+        JavaWsClientDemo demo = new JavaWsClientDemo(new URI("ws://sandbox.kaazing.net/echo"));
+        switch (args.length){
+            case 0:
+                demo = new JavaWsClientDemo(new URI("ws://sandbox.kaazing.net/echo"));
+                break;
+            case 1:
+                demo = new JavaWsClientDemo(new URI(args[0]));
+                break;
+            default:
+                System.out.println("Possible usage of the Kaazing Java JMS Demo: \n" +
+                        "   1. If you want to connect to our default URI and default credentials (guest/guest): \n" +
+                        "       /java-ws-demo\n" +
+                        "   2. If you want to connect to your own local Kaazing Gateway URI (ex: *ws://localhost:8000/jms*):\n" +
+                        "       /java-ws-demo '{YOUR.GATEWAY.URI}' \n" +
+                        "Please restart your the Kaazing Java AMQP Demo and input the correct parameters as stated above!");
+                System.exit(1);
+        }
+        demo.handleConnection();
+        System.out.println("Kaazing Java WS Demo App. Copyright (C) 2017 Kaazing, Inc.");
+        BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
+        while (true) {
+            String text = console.readLine();
+            if (text.toLowerCase().equals("<exit>"))
+                break;
+            // Send as a text
+            demo.sendMessage(text);
+        }
+        demo.disconnect();
+    }
+}


### PR DESCRIPTION
Fixed problem with connecting to wss in all 3 j2se demos, also cleaned up the projects, also added functionality for starting the program with a user inputed URI, username and password.

The JMS, AMQP and WS where not running OOTB because they where setup with a `wss://sandbox.kaazing.net/*` . This would cause a  problem because it could not find the certificate in the Java cacert and the connection could never be established and the apps would either crash or just not function at all.
Also because the URI was hard coded in the app, it was not user friendly. I made changes to the app so that it will start with `ws://sandbox.kaazing.net/*` by default, but now the user can also give arguments to the programs to start them with their own URI, username and passwords. I decided to change the URI from `WSS` to `WS` because using actual SSL connection in java is hard, the user would have to add `sandbox.kaazing.net` certificate into their local java cacert. The user could still use a `WSS` if they would input it the `WSS` URI as a command line argument and if they would import the appropriate certificate in java cacert.
Added a guide for starting each app inside the appropriate README.md and in the actual program in case someone inputs the wrong number of command line arguments.
Also all the demos had all they're functionality inside the class constructor, so I changed that to better reflect Java best practices.